### PR TITLE
Fix the customized sync call entry function not being exported

### DIFF
--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -779,6 +779,7 @@ void LinkerDriver::link(ArrayRef<const char *> argsArr) {
        // Is sync_call entry symbol found
        if (toString(*sym) == "sync_call") { // OK to hard code sync call entry here. Spring validate the entry function name to be "sync_call"
           symtab->syncCallEntryIsUndefined = false;
+          sym->setHidden(false); // Unhide it such that it can be put in the export section
        }
 
        if (!symtab->entryIsUndefined && !symtab->syncCallEntryIsUndefined) {

--- a/wasm/MarkLive.cpp
+++ b/wasm/MarkLive.cpp
@@ -118,10 +118,15 @@ void lld::wasm::markLive() {
         }
      }
 
-     if (has_sync_calls) {
+     // If there are functions tagged as sync calls or customized
+     // sync call entry function is provided, mark relevant functions live
+     if (has_sync_calls || !symtab->syncCallEntryIsUndefined) {
         enqueue(WasmSym::syncCallFunc);
-        enqueue(symtab->find("__eos_get_sync_call_data_"));
-        enqueue(symtab->find("__eos_get_sync_call_data_header_"));
+
+        if (has_sync_calls) { // only required by generated sync call entry function
+           enqueue(symtab->find("__eos_get_sync_call_data_"));
+           enqueue(symtab->find("__eos_get_sync_call_data_header_"));
+        }
      }
 
      for (const auto& import : wasmObj->imports()) {


### PR DESCRIPTION
To make the customized sync call entry function exportable, we need to set it unhidden and mark it live.